### PR TITLE
Document local testing workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,12 @@ ANALYTICS_SERVICE_URL=http://localhost:8002
 PETITION_SERVICE_URL=http://localhost:8003
 
 # =============================================================================
+# n8n Workflow Defaults
+# =============================================================================
+WEBHOOK_BASE_URL=http://localhost:5678
+NOTIFICATION_EMAIL=alerts@unburden-america.com
+
+# =============================================================================
 # Development Settings
 # =============================================================================
 ENVIRONMENT=development

--- a/README-Docker.md
+++ b/README-Docker.md
@@ -61,6 +61,9 @@ Analytics ← Content ← Petition ← Verification Gates
 ```bash
 # Security (CHANGE THESE!)
 POSTGRES_PASSWORD=your_secure_password
+AGENT_DB_PASSWORD=agent_db_password
+ANALYTICS_DB_PASSWORD=analytics_db_password
+PETITION_DB_PASSWORD=petition_db_password
 N8N_JWT_SECRET=your_jwt_secret_32_chars_min
 API_SECRET_KEY=your_api_secret_32_chars_min
 
@@ -72,6 +75,11 @@ ANTHROPIC_API_KEY=sk-ant-your-anthropic-key
 SMTP_HOST=smtp.gmail.com
 SMTP_USER=your-email@gmail.com
 SMTP_PASS=your-app-password
+SMTP_SENDER=noreply@your-domain.com
+
+# n8n Workflow Defaults
+WEBHOOK_BASE_URL=http://localhost:5678
+NOTIFICATION_EMAIL=alerts@your-domain.com
 ```
 
 ### Optional Configuration

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -122,3 +122,4 @@ echo "   Stop all: docker-compose down"
 echo "   View logs: docker-compose logs -f [service]"
 echo "   Restart service: docker-compose restart [service]"
 echo "   Update services: docker-compose pull && docker-compose up -d"
+

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,10 @@
+# Testing Guide
+
+To validate configuration files and the MCP orchestrator locally, run the bootstrap and verify scripts:
+
+```bash
+scripts/bootstrap_local.sh
+scripts/verify_build.sh
+```
+
+The bootstrap script launches the MCP server on port 7801, and the verify script checks JSON/YAML syntax before issuing a dry-run `route_intent` call. A successful run prints the accepted workflow DAG response.


### PR DESCRIPTION
## Summary
- add a testing guide that walks through the bootstrap and verification scripts used for local validation

## Testing
- scripts/bootstrap_local.sh
- scripts/verify_build.sh

------
https://chatgpt.com/codex/tasks/task_e_68dafc7011b0832f99d68e27b65e1986